### PR TITLE
Kill a confusing unused line

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var shortenedURLLength = 27;
 var maxTweetMessageLength = 140;
- - shortenedURLLength - 2;
 var ellipsis = '\u2026';
 
 function truncateToTweet(opts) {


### PR DESCRIPTION
I initially thought that there's a bug, but then I noticed the semicolon. That 3rd line is much better off dead.
